### PR TITLE
Handle relative links in language urls

### DIFF
--- a/testdata/github.com_trending_relativepaths.html
+++ b/testdata/github.com_trending_relativepaths.html
@@ -1,0 +1,594 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <link rel="dns-prefetch" href="https://assets-cdn.github.com">
+    <link rel="dns-prefetch" href="https://avatars0.githubusercontent.com">
+    <link rel="dns-prefetch" href="https://avatars1.githubusercontent.com">
+    <link rel="dns-prefetch" href="https://avatars2.githubusercontent.com">
+    <link rel="dns-prefetch" href="https://avatars3.githubusercontent.com">
+    <link rel="dns-prefetch" href="https://github-cloud.s3.amazonaws.com">
+    <link rel="dns-prefetch" href="https://user-images.githubusercontent.com/">
+
+    <meta content="origin-when-cross-origin" name="referrer" />
+
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/frameworks-e04a23d39bf81b7db3c635177756ef51bc171feb440be9e174933c6eb56382da.css" integrity="sha256-4Eoj05v4G32zxjUXd1bvUbwXH+tEC+nhdJM8brVjgto=" media="all" rel="stylesheet" />
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/github-3dc65358913934c77ed38ef6979525393a285062908a13a901527639c133c821.css" integrity="sha256-PcZTWJE5NMd+0472l5UlOTooUGKQihOpAVJ2OcEzyCE=" media="all" rel="stylesheet" />
+
+
+
+
+
+    <meta name="viewport" content="width=device-width">
+
+    <title>Trending  repositories on GitHub today</title>
+    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
+    <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
+    <meta property="fb:app_id" content="1401488693436528">
+
+    <meta property="og:url" content="https://github.com">
+    <meta property="og:site_name" content="GitHub">
+    <meta property="og:title" content="Build software better, together">
+    <meta property="og:description" content="GitHub is where people build software. More than 22 million people use GitHub to discover, fork, and contribute to over 61 million projects.">
+    <meta property="og:image" content="https://assets-cdn.github.com/images/modules/open_graph/github-logo.png">
+    <meta property="og:image:type" content="image/png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="1200">
+    <meta property="og:image" content="https://assets-cdn.github.com/images/modules/open_graph/github-mark.png">
+    <meta property="og:image:type" content="image/png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="620">
+    <meta property="og:image" content="https://assets-cdn.github.com/images/modules/open_graph/github-octocat.png">
+    <meta property="og:image:type" content="image/png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="620">
+
+
+    <link rel="assets" href="https://assets-cdn.github.com/">
+    <link rel="web-socket" href="wss://live.github.com/_sockets/VjI6MTgzNDIyNDM2OjY3MWU4OWZjOTc0ZmI0NzcxZjNlNTU2ZWRkMjY4NmFiYzA5OGMzNTQxNzIwYWYyODk1MGZlNjYzMzBmZWUxNWE=--c6ce848bffe16de6b1c792f735d3f5bc0c63ca35">
+    <meta name="pjax-timeout" content="1000">
+    <link rel="sudo-modal" href="/sessions/sudo_modal">
+    <meta name="request-id" content="C2D8:7758:1761323:22CB5E2:5958FF52" data-pjax-transient>
+
+
+    <meta name="selected-link" value="trending_repositories" data-pjax-transient>
+
+    <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
+    <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
+    <meta name="google-analytics" content="UA-3769691-2">
+
+    <meta content="collector.githubapp.com" name="octolytics-host" /><meta content="github" name="octolytics-app-id" /><meta content="https://collector.githubapp.com/github-external/browser_event" name="octolytics-event-url" /><meta content="C2D8:7758:1761323:22CB5E2:5958FF52" name="octolytics-dimension-request_id" /><meta content="iad" name="octolytics-dimension-region_edge" /><meta content="iad" name="octolytics-dimension-region_render" /><meta content="320064" name="octolytics-actor-id" /><meta content="andygrunwald" name="octolytics-actor-login" /><meta content="9e20195e45e5e7e9003ffc54d3f94ea0a9692ddfc49a11a6b35adc3c53e34c54" name="octolytics-actor-hash" />
+
+
+
+
+
+    <meta class="js-ga-set" name="dimension1" content="Logged In">
+
+
+
+
+    <meta name="hostname" content="github.com">
+    <meta name="user-login" content="andygrunwald">
+
+    <meta name="expected-hostname" content="github.com">
+    <meta name="js-proxy-site-detection-payload" content="N2JhOGY3MmRkOTEzYTRhMGM3OWYwNjc2MTEyMTgxNGZmZWRiMDM2NzJhOTE5MGU5NWU0NWE1NTJmOGMzN2M2OXx7InJlbW90ZV9hZGRyZXNzIjoiMjE3LjIyNC4xMTYuMTkwIiwicmVxdWVzdF9pZCI6IkMyRDg6Nzc1ODoxNzYxMzIzOjIyQ0I1RTI6NTk1OEZGNTIiLCJ0aW1lc3RhbXAiOjE0OTkwMDQ3NTUsImhvc3QiOiJnaXRodWIuY29tIn0=">
+
+
+    <meta name="html-safe-nonce" content="e4f0f4a49ae5bf62b7e265585929017fbc5a79e4">
+
+    <meta http-equiv="x-pjax-version" content="e87457103958760f131cc966530f53fd">
+
+
+    <meta name="viewport" content="width=device-width">
+    <link crossorigin="anonymous" href="https://assets-cdn.github.com/assets/site-0985c539aa8585eaf2bfff13b4cbb98befa6556d244e6cd5cf4ce0a57700d11e.css" integrity="sha256-CYXFOaqFheryv/8TtMu5i++mVW0kTmzVz0zgpXcA0R4=" media="all" rel="stylesheet" />
+
+
+    <link rel="canonical" href="https://github.com/trending" data-pjax-transient>
+
+
+    <meta name="browser-stats-url" content="https://api.github.com/_private/browser/stats">
+
+    <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors">
+
+    <link rel="mask-icon" href="https://assets-cdn.github.com/pinned-octocat.svg" color="#000000">
+    <link rel="icon" type="image/x-icon" href="https://assets-cdn.github.com/favicon.ico">
+
+    <meta name="theme-color" content="#1e2327">
+
+
+    <meta name="u2f-support" content="true">
+
+</head>
+
+<body class="logged-in env-production emoji-size-boost page-responsive min-width-0 site-header-dark">
+
+
+
+
+<div class="position-relative js-header-wrapper ">
+    <a href="#start-of-content" tabindex="1" class="bg-black text-white p-3 show-on-focus js-skip-to-content">Skip to content</a>
+    <div id="js-pjax-loader-bar" class="pjax-loader-bar"><div class="progress"></div></div>
+
+
+
+
+
+
+
+    <header class="site-header js-details-container Details" role="banner">
+        <div class="site-nav-container">
+            <a class="header-logo-invertocat" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark">
+                <svg aria-hidden="true" class="octicon octicon-mark-github" height="32" version="1.1" viewBox="0 0 16 16" width="32"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+            </a>
+
+            <button class="btn-link float-right site-header-toggle js-details-target" type="button" aria-label="Toggle navigation" aria-expanded="false">
+                <svg aria-hidden="true" class="octicon octicon-three-bars" height="24" version="1.1" viewBox="0 0 12 16" width="18"><path fill-rule="evenodd" d="M11.41 9H.59C0 9 0 8.59 0 8c0-.59 0-1 .59-1H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zm0-4H.59C0 5 0 4.59 0 4c0-.59 0-1 .59-1H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1h.01zM.59 11H11.4c.59 0 .59.41.59 1 0 .59 0 1-.59 1H.59C0 13 0 12.59 0 12c0-.59 0-1 .59-1z"/></svg>
+            </button>
+
+            <div class="site-header-menu">
+                <nav class="site-header-nav">
+                    <a href="/features" class="js-selected-navigation-item nav-item" data-ga-click="Header, click, Nav menu - item:features" data-selected-links="/features /features/code-review /features/project-management /features/integrations /features">
+                        Features
+                    </a>        <a href="/business" class="js-selected-navigation-item nav-item" data-ga-click="Header, click, Nav menu - item:business" data-selected-links="/business /business/security /business/customers /business">
+                    Business
+                </a>        <a href="/explore" class="js-selected-navigation-item selected nav-item" data-ga-click="Header, click, Nav menu - item:explore" data-selected-links="/explore /trending /trending/developers /stars /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship showcases showcases_search showcases_landing /explore">
+                    Explore
+                </a>            <a href="/marketplace" class="js-selected-navigation-item nav-item" data-ga-click="Header, click, Nav menu - item:marketplace" data-selected-links=" /marketplace">
+                    Marketplace
+                </a>        <a href="/pricing" class="js-selected-navigation-item nav-item" data-ga-click="Header, click, Nav menu - item:pricing" data-selected-links="/pricing /pricing/developer /pricing/team /pricing/business-hosted /pricing/business-enterprise /pricing">
+                    Pricing
+                </a>      </nav>
+
+                <div class="site-header-actions">
+                    <div class="header-search   js-site-search" role="search">
+                        <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/search" class="js-site-search-form" data-unscoped-search-url="/search" method="get"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div>
+                        <label class="form-control header-search-wrapper js-chromeless-input-container">
+                            <a href="/trending" class="header-search-scope no-underline">/trending</a>
+                            <input type="text"
+                                   class="form-control header-search-input js-site-search-focus "
+                                   data-hotkey="s"
+                                   name="q"
+                                   value=""
+                                   placeholder="Search GitHub"
+                                   aria-label="Search GitHub"
+                                   data-unscoped-placeholder="Search GitHub"
+                                   data-scoped-placeholder="Search"
+                                   autocapitalize="off">
+                            <input type="hidden" class="js-site-search-type-field" name="type" >
+                        </label>
+                    </form></div>
+
+
+                    <a class="text-bold site-header-link" href="https://github.com/" data-ga-click="(Logged in) Header, clicked Your dashboard, text:your dashboard"><img alt="@andygrunwald" class="avatar mr-2 v-align-text-bottom" height="17" src="https://avatars3.githubusercontent.com/u/320064?v=3&amp;s=34" width="17" />Your dashboard</a>
+                </div>
+            </div>
+        </div>
+    </header>
+
+
+
+
+
+</div>
+
+<div id="start-of-content" class="show-on-focus"></div>
+
+<div id="js-flash-container">
+</div>
+
+
+
+<div role="main">
+
+    <div class="pagehead">
+        <div class="container-lg p-responsive text-center clearfix">
+            <h1 class="float-sm-left mb-3 mb-sm-0">
+                <a class="pagehead-heading" href="/explore">
+                    Explore GitHub
+                </a>
+            </h1>
+            <nav class="underline-nav float-sm-right mx-auto" role="navigation" data-pjax>
+                <a href="/showcases" class="js-selected-navigation-item underline-nav-item" data-selected-links="showcases showcases_search showcases_landing /showcases">
+                    <svg aria-hidden="true" class="octicon octicon-megaphone" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M10 1c-.17 0-.36.05-.52.14C8.04 2.02 4.5 4.58 3 5c-1.38 0-3 .67-3 2.5S1.63 10 3 10c.3.08.64.23 1 .41V15h2v-3.45c1.34.86 2.69 1.83 3.48 2.31.16.09.34.14.52.14.52 0 1-.42 1-1V2c0-.58-.48-1-1-1zm0 12c-.38-.23-.89-.58-1.5-1-.16-.11-.33-.22-.5-.34V3.31c.16-.11.31-.2.47-.31.61-.41 1.16-.77 1.53-1v11zm2-6h4v1h-4V7zm0 2l4 2v1l-4-2V9zm4-6v1l-4 2V5l4-2z"/></svg> Showcases
+                </a>  <a href="/trending" class="js-selected-navigation-item selected underline-nav-item" data-selected-links="trending_developers trending_repositories /trending">
+                <svg aria-hidden="true" class="octicon octicon-flame" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M5.05.31c.81 2.17.41 3.38-.52 4.31C3.55 5.67 1.98 6.45.9 7.98c-1.45 2.05-1.7 6.53 3.53 7.7-2.2-1.16-2.67-4.52-.3-6.61-.61 2.03.53 3.33 1.94 2.86 1.39-.47 2.3.53 2.27 1.67-.02.78-.31 1.44-1.13 1.81 3.42-.59 4.78-3.42 4.78-5.56 0-2.84-2.53-3.22-1.25-5.61-1.52.13-2.03 1.13-1.89 2.75.09 1.08-1.02 1.8-1.86 1.33-.67-.41-.66-1.19-.06-1.78C8.18 5.31 8.68 2.45 5.05.32L5.03.3l.02.01z"/></svg> Trending
+            </a></nav>
+
+        </div>
+    </div>
+
+
+    <div class="explore-pjax-container container-lg p-responsive clearfix">
+        <div class="gutter-md">
+            <div class="text-center mt-2 mx-auto mb-5 anim-fade-in">
+                <h2 class="f1 text-normal mb-1">Trending in open source</h2>
+                <p class="lead mt-1 mb-3">See what the GitHub community is most excited about today.</p>
+            </div>
+
+            <div class="col-md-9 float-md-left">
+                <div class="tabnav">
+                    <div class="float-sm-right mb-2 mb-sm-0">
+                        <div class="select-menu js-menu-container js-select-menu select-menu-modal-right">
+                            <button class="btn btn-sm select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+                                <i>Trending:</i>
+                                <span class="js-select-button">today</span>
+                            </button>
+                            <div class="select-menu-modal-holder js-menu-content js-navigation-container">
+                                <div class="select-menu-modal">
+                                    <div class="select-menu-header">
+                                        <svg aria-label="Close" class="octicon octicon-x js-menu-close" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"/></svg>
+                                        <span class="select-menu-title">Adjust time span</span>
+                                    </div>
+
+                                    <div class="select-menu-list" role="menu">
+                                        <div>
+                                            <a class="select-menu-item js-navigation-item selected" href="https://github.com/trending?since=daily" data-pjax>
+                                                <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5z"/></svg>
+                                                <span class="select-menu-item-text js-select-button-text">today</span>
+                                            </a>
+                                            <a class="select-menu-item js-navigation-item " href="https://github.com/trending?since=weekly" data-pjax>
+                                                <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5z"/></svg>
+                                                <span class="select-menu-item-text js-select-button-text">this week</span>
+                                            </a>
+                                            <a class="select-menu-item js-navigation-item " href="https://github.com/trending?since=monthly" data-pjax>
+                                                <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5z"/></svg>
+                                                <span class="select-menu-item-text js-select-button-text">this month</span>
+                                            </a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+                    <nav class="tabnav-tabs" data-pjax>
+                        <a href="https://github.com/trending" class="js-selected-navigation-item selected tabnav-tab" data-selected-links="trending_repositories https://github.com/trending">Repositories</a>
+                        <a href="https://github.com/trending/developers" class="js-selected-navigation-item tabnav-tab" data-selected-links="trending_developers https://github.com/trending/developers">Developers</a>
+                    </nav>
+
+                </div>
+                <div class="explore-content">
+                    <ol class="repo-list">
+                        <li class="col-12 d-block width-full py-4 border-bottom" id="pa-go-tooling-workshop">
+                            <div class="d-inline-block col-9 mb-1">
+                                <h3>
+                                    <a href="/campoy/go-tooling-workshop">
+                                        <span class="text-normal">campoy / </span>go-tooling-workshop
+                                    </a>    </h3>
+                            </div>
+
+                            <div class="float-right">
+
+                                <div class="js-toggler-container js-social-container starring-container ">
+                                    <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/campoy/go-tooling-workshop/unstar" class="starred" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="h5lf3iN0DOhJ3m7Dj7o9hyWZ9DMmB4ufbG9OwRkQWH5P6vRHd9E9EnrijtYS2bsAQNJIQ+EVHKg7C6qnziY8Zg==" /></div>
+                                    <button
+                                            type="submit"
+                                            class="btn btn-sm  js-toggler-target"
+                                            aria-label="Unstar this repository" title="Unstar campoy/go-tooling-workshop"
+                                            data-ga-click="Repository, click unstar button, action:trending#index; text:Unstar">
+                                        <svg aria-hidden="true" class="octicon octicon-star" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74z"/></svg>
+                                        Unstar
+                                    </button>
+                                </form>
+                                    <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/campoy/go-tooling-workshop/star" class="unstarred" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="bYFuQGwCXfmhp6kwM3H5CdNz88H0bWCqB2/A5aZifGj2mjrMvF0bbjrjxrt9RnPQQlAjZBd6/MV05TcbIVRxQg==" /></div>
+                                    <button
+                                            type="submit"
+                                            class="btn btn-sm  js-toggler-target"
+                                            aria-label="Star this repository" title="Star campoy/go-tooling-workshop"
+                                            data-ga-click="Repository, click star button, action:trending#index; text:Star">
+                                        <svg aria-hidden="true" class="octicon octicon-star" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74z"/></svg>
+                                        Star
+                                    </button>
+                                </form>  </div>
+
+                            </div>
+
+                            <div class="py-1">
+                                <p class="col-9 d-inline-block text-gray m-0 pr-4">
+                                    A workshop covering all the tools gophers use in their day to day life
+                                </p>
+                            </div>
+
+                            <div class="f6 text-gray mt-2">
+      <span class="d-inline-block mr-3">
+          <span class="repo-language-color ml-0" style="background-color:#375eab;"></span>
+        <span itemprop="programmingLanguage">
+          Go
+        </span>
+      </span>
+
+                                <a class="muted-link d-inline-block mr-3" href="/campoy/go-tooling-workshop/stargazers">
+                                    <svg aria-label="star" class="octicon octicon-star" height="16" role="img" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74z"/></svg>
+                                    553
+                                </a>
+
+                                <a class="muted-link d-inline-block mr-3" href="/campoy/go-tooling-workshop/network">
+                                    <svg aria-label="fork" class="octicon octicon-repo-forked" height="16" role="img" version="1.1" viewBox="0 0 10 16" width="10"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
+                                    25
+                                </a>
+
+
+                                Built by
+                                <a href="/campoy/go-tooling-workshop/graphs/contributors" class="no-underline">
+                                    <img alt="@campoy" class="avatar mb-1" height="20" src="https://avatars2.githubusercontent.com/u/2237452?v=3&amp;s=40" title="campoy" width="20" />
+                                </a>
+
+                                <span class="float-right">
+        <svg aria-hidden="true" class="octicon octicon-star" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74z"/></svg>
+        164 stars today
+      </span>
+                            </div>
+                        </li>
+
+                        <li class="col-12 d-block width-full py-4 border-bottom" id="pa-dnssearch">
+                            <div class="d-inline-block col-9 mb-1">
+                                <h3>
+                                    <a href="/evilsocket/dnssearch">
+                                        <span class="text-normal">evilsocket / </span>dnssearch
+                                    </a>    </h3>
+                            </div>
+
+                            <div class="float-right">
+
+                                <div class="js-toggler-container js-social-container starring-container ">
+                                    <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/evilsocket/dnssearch/unstar" class="starred" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="rIOuRI3o7vh/iZ92FMwvf80Bp3rsPO4Dr6Z5zClF7O6JCqpp/JWhNu5tTA0DWu2+fqJrGyaIj/EELaHZgcRX0w==" /></div>
+                                    <button
+                                            type="submit"
+                                            class="btn btn-sm  js-toggler-target"
+                                            aria-label="Unstar this repository" title="Unstar evilsocket/dnssearch"
+                                            data-ga-click="Repository, click unstar button, action:trending#index; text:Unstar">
+                                        <svg aria-hidden="true" class="octicon octicon-star" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74z"/></svg>
+                                        Unstar
+                                    </button>
+                                </form>
+                                    <!-- '"` --><!-- </textarea></xmp> --></option></form><form accept-charset="UTF-8" action="/evilsocket/dnssearch/star" class="unstarred" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="Mc74yoWjYS3rEjoiPapcS9uuHcj1pD02bUpWzRBASvCOKXpaKHjtyvoVTWWxLCXWyaeT+nDK5YxZ1ECC/tgNdg==" /></div>
+                                    <button
+                                            type="submit"
+                                            class="btn btn-sm  js-toggler-target"
+                                            aria-label="Star this repository" title="Star evilsocket/dnssearch"
+                                            data-ga-click="Repository, click star button, action:trending#index; text:Star">
+                                        <svg aria-hidden="true" class="octicon octicon-star" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74z"/></svg>
+                                        Star
+                                    </button>
+                                </form>  </div>
+
+                            </div>
+
+                            <div class="py-1">
+                                <p class="col-9 d-inline-block text-gray m-0 pr-4">
+                                    A subdomain enumeration tool.
+                                </p>
+                            </div>
+
+                            <div class="f6 text-gray mt-2">
+      <span class="d-inline-block mr-3">
+          <span class="repo-language-color ml-0" style="background-color:#375eab;"></span>
+        <span itemprop="programmingLanguage">
+          Go
+        </span>
+      </span>
+
+                                <a class="muted-link d-inline-block mr-3" href="/evilsocket/dnssearch/stargazers">
+                                    <svg aria-label="star" class="octicon octicon-star" height="16" role="img" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74z"/></svg>
+                                    120
+                                </a>
+
+                                <a class="muted-link d-inline-block mr-3" href="/evilsocket/dnssearch/network">
+                                    <svg aria-label="fork" class="octicon octicon-repo-forked" height="16" role="img" version="1.1" viewBox="0 0 10 16" width="10"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
+                                    14
+                                </a>
+
+
+                                Built by
+                                <a href="/evilsocket/dnssearch/graphs/contributors" class="no-underline">
+                                    <img alt="@evilsocket" class="avatar mb-1" height="20" src="https://avatars0.githubusercontent.com/u/86922?v=3&amp;s=40" title="evilsocket" width="20" />
+                                    <img alt="@infoslack" class="avatar mb-1" height="20" src="https://avatars1.githubusercontent.com/u/444911?v=3&amp;s=40" title="infoslack" width="20" />
+                                </a>
+
+                                <span class="float-right">
+        <svg aria-hidden="true" class="octicon octicon-star" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74z"/></svg>
+        102 stars today
+      </span>
+                            </div>
+                        </li>
+
+                    </ol>
+                </div>
+            </div>
+            <div class="col-md-3 float-md-left mt-3 mt-md-0">
+                <ul class="filter-list small" data-pjax>
+                    <li>
+                        <a href="https://github.com/trending" class="filter-item selected">All languages</a>
+                    </li>
+                    <li>
+                        <a href="https://github.com/trending/unknown" class="filter-item ">Unknown languages</a>
+                    </li>
+                    <li>
+                        <a href="https://github.com/trending/go" class="filter-item ">Go</a>
+                    </li>
+                    <li>
+                        <a href="https://github.com/trending/java" class="filter-item ">Java</a>
+                    </li>
+                    <li>
+                        <a href="https://github.com/trending/javascript" class="filter-item ">JavaScript</a>
+                    </li>
+                    <li>
+                        <a href="https://github.com/trending/php" class="filter-item ">PHP</a>
+                    </li>
+                </ul>
+
+                <div class="select-menu js-menu-container js-select-menu">
+                    <button class="btn btn-sm select-menu-button js-menu-target" type="button" aria-haspopup="true" aria-expanded="false">
+                        <svg aria-hidden="true" class="octicon octicon-list-unordered" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M2 13c0 .59 0 1-.59 1H.59C0 14 0 13.59 0 13c0-.59 0-1 .59-1h.81c.59 0 .59.41.59 1H2zm2.59-9h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1H4.59C4 2 4 2.41 4 3c0 .59 0 1 .59 1zM1.41 7H.59C0 7 0 7.41 0 8c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0-5H.59C0 2 0 2.41 0 3c0 .59 0 1 .59 1h.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm10 5H4.59C4 7 4 7.41 4 8c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01zm0 5H4.59C4 12 4 12.41 4 13c0 .59 0 1 .59 1h6.81c.59 0 .59-.41.59-1 0-.59 0-1-.59-1h.01z"/></svg>
+                        <i>Other:</i>
+                        <span class="js-select-button">Languages</span>
+                    </button>
+
+                    <div class="select-menu-modal-holder js-menu-content js-navigation-container">
+                        <div class="select-menu-modal">
+                            <div class="select-menu-header">
+                                <svg aria-label="Close" class="octicon octicon-x js-menu-close" height="16" role="img" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"/></svg>
+                                <span class="select-menu-title">Other Languages</span>
+                            </div>
+
+                            <div class="select-menu-filters">
+                                <div class="select-menu-text-filter">
+                                    <input type="text" id="text-filter-field" class="form-control js-filterable-field js-navigation-enable" placeholder="Filter Languages" aria-label="Type or choose a language">
+                                </div>
+                            </div>
+
+                            <div class="select-menu-list" data-pjax role="menu">
+
+
+                                <div data-filterable-for="text-filter-field" data-filterable-type="substring">
+                                    <a href="/trending/abap" class="select-menu-item js-navigation-item " role="menuitem">
+                                    <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5z"/></svg>
+                                    <span class='select-menu-item-text js-select-button-text js-navigation-open'>ABAP</span>
+                                </a>            <a href="/trending/actionscript" class="select-menu-item js-navigation-item " role="menuitem">
+                                    <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5z"/></svg>
+                                    <span class='select-menu-item-text js-select-button-text js-navigation-open'>ActionScript</span>
+                                </a>            <a href="/trending/ada" class="select-menu-item js-navigation-item " role="menuitem">
+                                    <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5z"/></svg>
+                                    <span class='select-menu-item-text js-select-button-text js-navigation-open'>Ada</span>
+                                </a>            <a href="/trending/agda" class="select-menu-item js-navigation-item " role="menuitem">
+                                    <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5z"/></svg>
+                                    <span class='select-menu-item-text js-select-button-text js-navigation-open'>Agda</span>
+                                </a>            <a href="/trending/ags-script" class="select-menu-item js-navigation-item " role="menuitem">
+                                    <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5z"/></svg>
+                                    <span class='select-menu-item-text js-select-button-text js-navigation-open'>AGS Script</span>
+                                </a>            <a href="/trending/alloy" class="select-menu-item js-navigation-item " role="menuitem">
+                                    <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5z"/></svg>
+                                    <span class='select-menu-item-text js-select-button-text js-navigation-open'>Alloy</span>
+                                </a>            <a href="/trending/ampl" class="select-menu-item js-navigation-item " role="menuitem">
+                                    <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5z"/></svg>
+                                    <span class='select-menu-item-text js-select-button-text js-navigation-open'>AMPL</span>
+                                </a>            <a href="/trending/antlr" class="select-menu-item js-navigation-item " role="menuitem">
+                                    <svg aria-hidden="true" class="octicon octicon-check select-menu-item-icon" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5z"/></svg>
+                                    <span class='select-menu-item-text js-select-button-text js-navigation-open'>ANTLR</span>
+                                </a>        </div>
+
+                            </div>
+
+                            <div class="select-menu-loading-overlay anim-pulse">
+                                <svg aria-hidden="true" class="octicon octicon-octoface" height="32" version="1.1" viewBox="0 0 16 16" width="32"><path fill-rule="evenodd" d="M14.7 5.34c.13-.32.55-1.59-.13-3.31 0 0-1.05-.33-3.44 1.3-1-.28-2.07-.32-3.13-.32s-2.13.04-3.13.32c-2.39-1.64-3.44-1.3-3.44-1.3-.68 1.72-.26 2.99-.13 3.31C.49 6.21 0 7.33 0 8.69 0 13.84 3.33 15 7.98 15S16 13.84 16 8.69c0-1.36-.49-2.48-1.3-3.35zM8 14.02c-3.3 0-5.98-.15-5.98-3.35 0-.76.38-1.48 1.02-2.07 1.07-.98 2.9-.46 4.96-.46 2.07 0 3.88-.52 4.96.46.65.59 1.02 1.3 1.02 2.07 0 3.19-2.68 3.35-5.98 3.35zM5.49 9.01c-.66 0-1.2.8-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.54-1.78-1.2-1.78zm5.02 0c-.66 0-1.2.79-1.2 1.78s.54 1.79 1.2 1.79c.66 0 1.2-.8 1.2-1.79s-.53-1.78-1.2-1.78z"/></svg>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="protip protip-callout">
+                    <strong class="protip">ProTip!</strong>
+                    Looking for most starred  repositories?
+                    <a href="/search?q=stars%3A%3E1&amp;s=stars&amp;type=Repositories">Try this search</a>
+                </div>
+
+            </div>
+        </div>
+    </div>
+
+    <div class="modal-backdrop js-touch-events"></div>
+
+</div>
+
+<div class="site-footer-container mt-6" role="contentinfo">
+    <div class="d-flex flex-wrap py-5 mb-5">
+        <div class="site-footer-col mb-3">
+            <svg aria-hidden="true" class="octicon octicon-logo-github" height="24" version="1.1" viewBox="0 0 45 16" width="67"><path fill-rule="evenodd" d="M18.53 12.03h-.02c.009 0 .015.01.024.011h.006l-.01-.01zm.004.011c-.093.001-.327.05-.574.05-.78 0-1.05-.36-1.05-.83V8.13h1.59c.09 0 .16-.08.16-.19v-1.7c0-.09-.08-.17-.16-.17h-1.59V3.96c0-.08-.05-.13-.14-.13h-2.16c-.09 0-.14.05-.14.13v2.17s-1.09.27-1.16.28c-.08.02-.13.09-.13.17v1.36c0 .11.08.19.17.19h1.11v3.28c0 2.44 1.7 2.69 2.86 2.69.53 0 1.17-.17 1.27-.22.06-.02.09-.09.09-.16v-1.5a.177.177 0 0 0-.146-.18zm23.696-2.2c0-1.81-.73-2.05-1.5-1.97-.6.04-1.08.34-1.08.34v3.52s.49.34 1.22.36c1.03.03 1.36-.34 1.36-2.25zm2.43-.16c0 3.43-1.11 4.41-3.05 4.41-1.64 0-2.52-.83-2.52-.83s-.04.46-.09.52c-.03.06-.08.08-.14.08h-1.48c-.1 0-.19-.08-.19-.17l.02-11.11c0-.09.08-.17.17-.17h2.13c.09 0 .17.08.17.17v3.77s.82-.53 2.02-.53l-.01-.02c1.2 0 2.97.45 2.97 3.88zm-8.72-3.61H33.84c-.11 0-.17.08-.17.19v5.44s-.55.39-1.3.39-.97-.34-.97-1.09V6.25c0-.09-.08-.17-.17-.17h-2.14c-.09 0-.17.08-.17.17v5.11c0 2.2 1.23 2.75 2.92 2.75 1.39 0 2.52-.77 2.52-.77s.05.39.08.45c.02.05.09.09.16.09h1.34c.11 0 .17-.08.17-.17l.02-7.47c0-.09-.08-.17-.19-.17zm-23.7-.01h-2.13c-.09 0-.17.09-.17.2v7.34c0 .2.13.27.3.27h1.92c.2 0 .25-.09.25-.27V6.23c0-.09-.08-.17-.17-.17zm-1.05-3.38c-.77 0-1.38.61-1.38 1.38 0 .77.61 1.38 1.38 1.38.75 0 1.36-.61 1.36-1.38 0-.77-.61-1.38-1.36-1.38zm16.49-.25h-2.11c-.09 0-.17.08-.17.17v4.09h-3.31V2.6c0-.09-.08-.17-.17-.17h-2.13c-.09 0-.17.08-.17.17v11.11c0 .09.09.17.17.17h2.13c.09 0 .17-.08.17-.17V8.96h3.31l-.02 4.75c0 .09.08.17.17.17h2.13c.09 0 .17-.08.17-.17V2.6c0-.09-.08-.17-.17-.17zM8.81 7.35v5.74c0 .04-.01.11-.06.13 0 0-1.25.89-3.31.89-2.49 0-5.44-.78-5.44-5.92S2.58 1.99 5.1 2c2.18 0 3.06.49 3.2.58.04.05.06.09.06.14L7.94 4.5c0 .09-.09.2-.2.17-.36-.11-.9-.33-2.17-.33-1.47 0-3.05.42-3.05 3.73s1.5 3.7 2.58 3.7c.92 0 1.25-.11 1.25-.11v-2.3H4.88c-.11 0-.19-.08-.19-.17V7.35c0-.09.08-.17.19-.17h3.74c.11 0 .19.08.19.17z"/></svg>
+            <p class="text-gray alt-text-small">
+                &copy; 2017
+            </p>
+        </div>
+        <div class="site-footer-col mb-3 pr-3">
+            <h4 class="mb-2">Features</h4>
+            <ul class="list-style-none text-gray">
+                <li class="lh-condensed mb-2"><a href="/features#code-review" class="muted-link alt-text-small">Code review</a></li>
+                <li class="lh-condensed mb-2"><a href="/features#project-management" class="muted-link alt-text-small">Project management</a></li>
+                <li class="lh-condensed mb-2"><a href="/features#community-management" class="muted-link alt-text-small">Community</a></li>
+                <li class="lh-condensed mb-2"><a href="/features#documentation" class="muted-link alt-text-small">Documentation</a></li>
+                <li class="lh-condensed mb-2"><a href="/features#code-hosting" class="muted-link alt-text-small">Code hosting</a></li>
+            </ul>
+        </div>
+        <div class="site-footer-col mb-3 pr-3">
+            <h4 class="mb-2">Platform</h4>
+            <ul class="list-style-none">
+                <li class="lh-condensed mb-2"><a href="https://atom.io" class="muted-link alt-text-small">Atom</a></li>
+                <li class="lh-condensed mb-2"><a href="http://electron.atom.io/" class="muted-link alt-text-small">Electron</a></li>
+                <li class="lh-condensed mb-2"><a href="https://desktop.github.com/" class="muted-link alt-text-small">GitHub Desktop</a></li>
+                <li class="lh-condensed mb-2"><a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api" class="muted-link alt-text-small">Developers</a></li>
+            </ul>
+        </div>
+        <div class="site-footer-col mb-3 pr-3">
+            <h4 class="mb-2">Community</h4>
+            <ul class="list-style-none">
+                <li class="lh-condensed mb-2"><a href="/personal" class="muted-link alt-text-small">Personal</a></li>
+                <li class="lh-condensed mb-2"><a href="/open-source" class="muted-link alt-text-small">Open source</a></li>
+                <li class="lh-condensed mb-2"><a href="/business" class="muted-link alt-text-small">For Business</a></li>
+                <li class="lh-condensed mb-2"><a href="https://education.github.com/" class="muted-link alt-text-small">For Education</a></li>
+                <li class="lh-condensed mb-2"><a href="https://community.github.com/" class="muted-link alt-text-small">Sponsorships</a></li>
+            </ul>
+        </div>
+        <div class="site-footer-col mb-3 pr-3">
+            <h4 class="mb-2">Company</h4>
+            <ul class="list-style-none">
+                <li class="lh-condensed mb-2"><a href="https://github.com/about" class="muted-link alt-text-small" data-ga-click="Footer, go to about, text:about">About</a></li>
+                <li class="lh-condensed mb-2"><a href="https://github.com/blog" class="muted-link alt-text-small" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
+                <li class="lh-condensed mb-2"><a href="/business/customers" class="muted-link alt-text-small">Customers</a></li>
+                <li class="lh-condensed mb-2"><a href="/about/careers" class="muted-link alt-text-small">Careers</a></li>
+                <li class="lh-condensed mb-2"><a href="/about/press" class="muted-link alt-text-small">Press</a></li>
+                <li class="lh-condensed mb-2"><a href="https://shop.github.com" class="muted-link alt-text-small">Shop</a></li>
+            </ul>
+        </div>
+        <div class="site-footer-col mb-3 pr-3">
+            <h4 class="mb-2">Resources</h4>
+            <ul class="list-style-none">
+                <li class="lh-condensed mb-2"><a href="https://github.com/contact" class="muted-link alt-text-small" data-ga-click="Footer, go to contact, text:contact">Contact GitHub</a></li>
+                <li class="lh-condensed mb-2"><a href="https://help.github.com" class="muted-link alt-text-small" data-ga-click="Footer, go to help, text:help">Help</a></li>
+                <li class="lh-condensed mb-2"><a href="https://status.github.com/" data-ga-click="Footer, go to status, text:status" class="muted-link alt-text-small">Status</a></li>
+                <li class="lh-condensed mb-2"><a href="https://github.com/site/terms" class="muted-link alt-text-small" data-ga-click="Footer, go to terms, text:terms">Terms</a></li>
+                <li class="lh-condensed mb-2"><a href="https://github.com/site/privacy" class="muted-link alt-text-small" data-ga-click="Footer, go to privacy, text:privacy">Privacy</a></li>
+                <li class="lh-condensed mb-2"><a href="https://github.com/security" class="muted-link alt-text-small" data-ga-click="Footer, go to security, text:security">Security</a></li>
+                <li class="lh-condensed mb-2"><a href="https://services.github.com/" class="muted-link alt-text-small">Training</a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+
+
+<div id="ajax-error-message" class="ajax-error-message flash flash-error">
+    <svg aria-hidden="true" class="octicon octicon-alert" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M8.865 1.52c-.18-.31-.51-.5-.87-.5s-.69.19-.87.5L.275 13.5c-.18.31-.18.69 0 1 .19.31.52.5.87.5h13.7c.36 0 .69-.19.86-.5.17-.31.18-.69.01-1L8.865 1.52zM8.995 13h-2v-2h2v2zm0-3h-2V6h2v4z"/></svg>
+    <button type="button" class="flash-close js-flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
+        <svg aria-hidden="true" class="octicon octicon-x" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"/></svg>
+    </button>
+    You can't perform that action at this time.
+</div>
+
+
+
+<script crossorigin="anonymous" integrity="sha256-nL0D6lZGHoSriVa/d5mpd9bMih+YTHG17LLt/bo9dz8=" src="https://assets-cdn.github.com/assets/frameworks-9cbd03ea56461e84ab8956bf7799a977d6cc8a1f984c71b5ecb2edfdba3d773f.js"></script>
+
+<script async="async" crossorigin="anonymous" integrity="sha256-MpVEs6V4fIUQfgMDkQu7L2eCLO/3/J/ptXlamQDQEwI=" src="https://assets-cdn.github.com/assets/github-329544b3a5787c85107e0303910bbb2f67822ceff7fc9fe9b5795a9900d01302.js"></script>
+
+
+
+
+<div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner d-none">
+    <svg aria-hidden="true" class="octicon octicon-alert" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M8.865 1.52c-.18-.31-.51-.5-.87-.5s-.69.19-.87.5L.275 13.5c-.18.31-.18.69 0 1 .19.31.52.5.87.5h13.7c.36 0 .69-.19.86-.5.17-.31.18-.69.01-1L8.865 1.52zM8.995 13h-2v-2h2v2zm0-3h-2V6h2v4z"/></svg>
+    <span class="signed-in-tab-flash">You signed in with another tab or window. <a href="">Reload</a> to refresh your session.</span>
+    <span class="signed-out-tab-flash">You signed out in another tab or window. <a href="">Reload</a> to refresh your session.</span>
+</div>
+<div class="facebox" id="facebox" style="display:none;">
+    <div class="facebox-popup">
+        <div class="facebox-content" role="dialog" aria-labelledby="facebox-header" aria-describedby="facebox-description">
+        </div>
+        <button type="button" class="facebox-close js-facebox-close" aria-label="Close modal">
+            <svg aria-hidden="true" class="octicon octicon-x" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"/></svg>
+        </button>
+    </div>
+</div>
+
+
+</body>
+</html>

--- a/trending.go
+++ b/trending.go
@@ -287,7 +287,12 @@ func (t *Trending) generateLanguages(mainSelector string) ([]Language, error) {
 
 	// Query our information
 	doc.Find(mainSelector).Each(func(i int, s *goquery.Selection) {
+		expectedPrefix := "https://github.com"
 		languageAddress, _ := s.Attr("href")
+		if !strings.HasPrefix(languageAddress, expectedPrefix) {
+			languageAddress = expectedPrefix + languageAddress
+		}
+
 		languageURLName := ""
 
 		filterURL, _ := url.Parse(languageAddress)

--- a/trending_test.go
+++ b/trending_test.go
@@ -244,6 +244,46 @@ func TestGetLanguages(t *testing.T) {
 	}
 }
 
+func TestGetLanguages_RelativePaths(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/trending", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		website := getContentOfFile("./testdata/github.com_trending_relativepaths.html")
+		fmt.Fprint(w, string(website))
+	})
+
+	languages, err := client.GetLanguages()
+	if err != nil {
+		t.Errorf("GetLanguages returned error: %v", err)
+	}
+
+	uAbap, _ := url.Parse("https://github.com/trending/abap")
+	uActionScript, _ := url.Parse("https://github.com/trending/actionscript")
+	uAda, _ := url.Parse("https://github.com/trending/ada")
+	uAgda, _ := url.Parse("https://github.com/trending/agda")
+	uAGS, _ := url.Parse("https://github.com/trending/ags-script")
+	uAlloy, _ := url.Parse("https://github.com/trending/alloy")
+	uAMPL, _ := url.Parse("https://github.com/trending/ampl")
+	uANTLR, _ := url.Parse("https://github.com/trending/antlr")
+
+	want := []Language{
+		{"ABAP", "abap", uAbap},
+		{"ActionScript", "actionscript", uActionScript},
+		{"Ada", "ada", uAda},
+		{"Agda", "agda", uAgda},
+		{"AGS Script", "ags-script", uAGS},
+		{"Alloy", "alloy", uAlloy},
+		{"AMPL", "ampl", uAMPL},
+		{"ANTLR", "antlr", uANTLR},
+	}
+
+	if !reflect.DeepEqual(languages, want) {
+		t.Errorf("GetLanguages returned %+v, want %+v", languages, want)
+	}
+}
+
 func TestGetLanguages_NoContent(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Github changed the hrefs on the trending page that filter by language. They are now using relative urls.
So where we used to see `https://github.com/trending/go`, now we see '/trending/go`. This made it so the GetLanguages call returned an empty string for the URLName property. The tests didn't catch this, since they are using older test data.

I now simply append the correct prefix to the url we are doing regex matches against. This would protect us if Github goes back to absolute URLS.

It would be good to check any other pages you are scraping to see if this effects them. I just use the GetLanguages method exclusively in my project, so that's where I noticed it.